### PR TITLE
feat(invoice): Add search_term filter for invoice list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,10 +627,10 @@ dependencies = [
 
 [[package]]
 name = "lago-client"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
- "lago-types 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lago-types 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito",
  "reqwest",
  "serde",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "lago-types"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "chrono",
  "reqwest",
@@ -658,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "lago-types"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0899c09b02ff16cfc08c60041b7c4b583c0b2abe84f58f0cd4d365068a6747"
+checksum = "4f65658594803e57c0696f7ad13aa95cfe806f493e03841bf2c97ee599fa3cb3"
 dependencies = [
  "chrono",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,10 +627,10 @@ dependencies = [
 
 [[package]]
 name = "lago-client"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
- "lago-types 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lago-types 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito",
  "reqwest",
  "serde",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "lago-types"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "chrono",
  "reqwest",
@@ -658,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "lago-types"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32332cbc7b35e33e0bf88ce08b14841edf35f9726966e676f8cafa4f91b942ab"
+checksum = "1d0899c09b02ff16cfc08c60041b7c4b583c0b2abe84f58f0cd4d365068a6747"
 dependencies = [
  "chrono",
  "reqwest",

--- a/lago-client/Cargo.toml
+++ b/lago-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lago-client"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2024"
 authors = ["Lago Team <tech@getlago.com>"]
 description = "Lago API client"
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/getlago/lago-rust-client"
 
 [dependencies]
-lago-types = "0.1.19"
+lago-types = "0.1.20"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/lago-client/Cargo.toml
+++ b/lago-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lago-client"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 authors = ["Lago Team <tech@getlago.com>"]
 description = "Lago API client"
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/getlago/lago-rust-client"
 
 [dependencies]
-lago-types = "0.1.18"
+lago-types = "0.1.19"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/lago-client/examples/invoice.rs
+++ b/lago-client/examples/invoice.rs
@@ -4,7 +4,6 @@ use lago_types::{
     requests::invoice::{
         DownloadInvoiceRequest, GetInvoiceRequest, ListCustomerInvoicesRequest,
         ListInvoicesRequest, UpdateInvoiceInput, UpdateInvoiceMetadataInput, UpdateInvoiceRequest,
-        VoidInvoiceRequest,
     },
 };
 
@@ -18,9 +17,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Found {} invoices", invoices.invoices.len());
 
     // Example 1b: Search invoices by number, customer name, or email
-    let search_request = ListInvoicesRequest::new().with_filters(
-        InvoiceFilters::new().with_search_term("LAR-F878-202501".to_string()),
-    );
+    let search_request = ListInvoicesRequest::new()
+        .with_filters(InvoiceFilters::new().with_search_term("LAR-F878-202501".to_string()));
     let search_results = client.list_invoices(Some(search_request)).await?;
     println!(
         "Found {} invoices matching search term",

--- a/lago-client/examples/invoice.rs
+++ b/lago-client/examples/invoice.rs
@@ -1,10 +1,7 @@
 use lago_client::LagoClient;
-use lago_types::{
-    filters::invoice::InvoiceFilters,
-    requests::invoice::{
-        DownloadInvoiceRequest, GetInvoiceRequest, ListCustomerInvoicesRequest,
-        ListInvoicesRequest, UpdateInvoiceInput, UpdateInvoiceMetadataInput, UpdateInvoiceRequest,
-    },
+use lago_types::requests::invoice::{
+    DownloadInvoiceRequest, GetInvoiceRequest, ListCustomerInvoicesRequest, ListInvoicesRequest,
+    UpdateInvoiceInput, UpdateInvoiceMetadataInput, UpdateInvoiceRequest,
 };
 
 #[tokio::main]
@@ -17,8 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Found {} invoices", invoices.invoices.len());
 
     // Example 1b: Search invoices by number, customer name, or email
-    let search_request = ListInvoicesRequest::new()
-        .with_filters(InvoiceFilters::new().with_search_term("LAR-F878-202501".to_string()));
+    let search_request = ListInvoicesRequest::new().with_search_term("LAR-F878-202501".to_string());
     let search_results = client.list_invoices(Some(search_request)).await?;
     println!(
         "Found {} invoices matching search term",

--- a/lago-client/examples/invoice.rs
+++ b/lago-client/examples/invoice.rs
@@ -1,7 +1,11 @@
 use lago_client::LagoClient;
-use lago_types::requests::invoice::{
-    DownloadInvoiceRequest, GetInvoiceRequest, ListCustomerInvoicesRequest, ListInvoicesRequest,
-    UpdateInvoiceInput, UpdateInvoiceMetadataInput, UpdateInvoiceRequest, VoidInvoiceRequest,
+use lago_types::{
+    filters::invoice::InvoiceFilters,
+    requests::invoice::{
+        DownloadInvoiceRequest, GetInvoiceRequest, ListCustomerInvoicesRequest,
+        ListInvoicesRequest, UpdateInvoiceInput, UpdateInvoiceMetadataInput, UpdateInvoiceRequest,
+        VoidInvoiceRequest,
+    },
 };
 
 #[tokio::main]
@@ -12,6 +16,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let list_request = ListInvoicesRequest::new();
     let invoices = client.list_invoices(Some(list_request)).await?;
     println!("Found {} invoices", invoices.invoices.len());
+
+    // Example 1b: Search invoices by number, customer name, or email
+    let search_request = ListInvoicesRequest::new().with_filters(
+        InvoiceFilters::new().with_search_term("LAR-F878-202501".to_string()),
+    );
+    let search_results = client.list_invoices(Some(search_request)).await?;
+    println!(
+        "Found {} invoices matching search term",
+        search_results.invoices.len()
+    );
 
     for invoice in &invoices.invoices {
         println!(

--- a/lago-types/Cargo.toml
+++ b/lago-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lago-types"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 authors = ["Lago Team <tech@getlago.com>"]
 description = "Types definitions for Lago API"

--- a/lago-types/Cargo.toml
+++ b/lago-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lago-types"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2024"
 authors = ["Lago Team <tech@getlago.com>"]
 description = "Types definitions for Lago API"

--- a/lago-types/README.md
+++ b/lago-types/README.md
@@ -81,6 +81,13 @@ let request = ListInvoicesRequest::new()
             .with_invoice_type(invoice_type)
     );
 
+// Search invoices by number, customer name, external_id, or email
+let request = ListInvoicesRequest::new()
+    .with_filters(
+        InvoiceFilters::new()
+            .with_search_term("INV-2024-001".to_string())
+    );
+
 // Convert to query parameters
 let params = request.to_query_params();
 ```

--- a/lago-types/README.md
+++ b/lago-types/README.md
@@ -83,10 +83,7 @@ let request = ListInvoicesRequest::new()
 
 // Search invoices by number, customer name, external_id, or email
 let request = ListInvoicesRequest::new()
-    .with_filters(
-        InvoiceFilters::new()
-            .with_search_term("INV-2024-001".to_string())
-    );
+    .with_search_term("INV-2024-001".to_string());
 
 // Convert to query parameters
 let params = request.to_query_params();

--- a/lago-types/src/filters/credit_note.rs
+++ b/lago-types/src/filters/credit_note.rs
@@ -9,7 +9,6 @@ pub struct CreditNoteFilter {
     pub external_customer_id: Option<String>,
     pub issuing_date_from: Option<String>,
     pub issuing_date_to: Option<String>,
-    pub search_term: Option<String>,
     pub currency: Option<String>,
     pub reason: Option<CreditNoteReason>,
     pub credit_status: Option<CreditNoteCreditStatus>,
@@ -47,12 +46,6 @@ impl CreditNoteFilter {
     /// Filter by issuing date to.
     pub fn with_issuing_date_to(mut self, to: String) -> Self {
         self.issuing_date_to = Some(to);
-        self
-    }
-
-    /// Search by id, number, customer name, external_id or email.
-    pub fn with_search_term(mut self, term: String) -> Self {
-        self.search_term = Some(term);
         self
     }
 
@@ -120,10 +113,6 @@ impl ListFilters for CreditNoteFilter {
 
         if let Some(ref to) = self.issuing_date_to {
             params.push(("issuing_date_to", to.clone()));
-        }
-
-        if let Some(ref term) = self.search_term {
-            params.push(("search_term", term.clone()));
         }
 
         if let Some(ref currency) = self.currency {

--- a/lago-types/src/filters/invoice.rs
+++ b/lago-types/src/filters/invoice.rs
@@ -16,7 +16,6 @@ pub struct InvoiceFilters {
     pub status: Option<InvoiceStatus>,
     pub payment_status: Option<InvoicePaymentStatus>,
     pub invoice_type: Option<InvoiceType>,
-    pub search_term: Option<String>,
 }
 
 impl InvoiceFilters {
@@ -112,18 +111,6 @@ impl InvoiceFilters {
         self.invoice_type = Some(invoice_type);
         self
     }
-
-    /// Search by id, number, customer name, external_id or email.
-    ///
-    /// # Arguments
-    /// * `term` - The search term to filter by
-    ///
-    /// # Returns
-    /// The modified filter instance for method chaining.
-    pub fn with_search_term(mut self, term: String) -> Self {
-        self.search_term = Some(term);
-        self
-    }
 }
 
 impl ListFilters for InvoiceFilters {
@@ -161,10 +148,6 @@ impl ListFilters for InvoiceFilters {
 
         if let Some(invoice_type) = &self.invoice_type {
             params.push(("invoice_type", format!("{invoice_type:?}").to_lowercase()));
-        }
-
-        if let Some(ref term) = self.search_term {
-            params.push(("search_term", term.clone()));
         }
 
         params

--- a/lago-types/src/filters/invoice.rs
+++ b/lago-types/src/filters/invoice.rs
@@ -16,6 +16,7 @@ pub struct InvoiceFilters {
     pub status: Option<InvoiceStatus>,
     pub payment_status: Option<InvoicePaymentStatus>,
     pub invoice_type: Option<InvoiceType>,
+    pub search_term: Option<String>,
 }
 
 impl InvoiceFilters {
@@ -111,6 +112,18 @@ impl InvoiceFilters {
         self.invoice_type = Some(invoice_type);
         self
     }
+
+    /// Search by id, number, customer name, external_id or email.
+    ///
+    /// # Arguments
+    /// * `term` - The search term to filter by
+    ///
+    /// # Returns
+    /// The modified filter instance for method chaining.
+    pub fn with_search_term(mut self, term: String) -> Self {
+        self.search_term = Some(term);
+        self
+    }
 }
 
 impl ListFilters for InvoiceFilters {
@@ -148,6 +161,10 @@ impl ListFilters for InvoiceFilters {
 
         if let Some(invoice_type) = &self.invoice_type {
             params.push(("invoice_type", format!("{invoice_type:?}").to_lowercase()));
+        }
+
+        if let Some(ref term) = self.search_term {
+            params.push(("search_term", term.clone()));
         }
 
         params

--- a/lago-types/src/requests/credit_note.rs
+++ b/lago-types/src/requests/credit_note.rs
@@ -9,6 +9,8 @@ use crate::models::{CreditNoteReason, CreditNoteRefundStatus, PaginationParams};
 pub struct ListCreditNotesRequest {
     pub pagination: PaginationParams,
     pub filters: CreditNoteFilter,
+    /// Search by id, number, customer name, external_id or email.
+    pub search_term: Option<String>,
 }
 
 impl ListCreditNotesRequest {
@@ -17,6 +19,7 @@ impl ListCreditNotesRequest {
         Self {
             pagination: PaginationParams::default(),
             filters: CreditNoteFilter::default(),
+            search_term: None,
         }
     }
 
@@ -32,10 +35,23 @@ impl ListCreditNotesRequest {
         self
     }
 
+    /// Sets the search term for the request.
+    ///
+    /// Search by id, number, customer name, external_id or email.
+    pub fn with_search_term(mut self, term: String) -> Self {
+        self.search_term = Some(term);
+        self
+    }
+
     /// Converts the request parameters into HTTP query parameters.
     pub fn to_query_params(&self) -> Vec<(&str, String)> {
         let mut params = self.pagination.to_query_params();
         params.extend(self.filters.to_query_params());
+
+        if let Some(ref term) = self.search_term {
+            params.push(("search_term", term.clone()));
+        }
+
         params
     }
 }

--- a/lago-types/src/requests/invoice.rs
+++ b/lago-types/src/requests/invoice.rs
@@ -12,6 +12,8 @@ use crate::filters::{common::ListFilters, invoice::InvoiceFilters};
 pub struct ListInvoicesRequest {
     pub pagination: PaginationParams,
     pub filters: InvoiceFilters,
+    /// Search by id, number, customer name, external_id or email.
+    pub search_term: Option<String>,
 }
 
 impl ListInvoicesRequest {
@@ -23,6 +25,7 @@ impl ListInvoicesRequest {
         Self {
             pagination: PaginationParams::default(),
             filters: InvoiceFilters::default(),
+            search_term: None,
         }
     }
 
@@ -50,6 +53,20 @@ impl ListInvoicesRequest {
         self
     }
 
+    /// Sets the search term for the request.
+    ///
+    /// Search by id, number, customer name, external_id or email.
+    ///
+    /// # Arguments
+    /// * `term` - The search term
+    ///
+    /// # Returns
+    /// The modified request instance for method chaining.
+    pub fn with_search_term(mut self, term: String) -> Self {
+        self.search_term = Some(term);
+        self
+    }
+
     /// Converts the request parameters into HTTP query parameters.
     ///
     /// # Returns
@@ -57,6 +74,11 @@ impl ListInvoicesRequest {
     pub fn to_query_params(&self) -> Vec<(&str, String)> {
         let mut params = self.pagination.to_query_params();
         params.extend(self.filters.to_query_params());
+
+        if let Some(ref term) = self.search_term {
+            params.push(("search_term", term.clone()));
+        }
+
         params
     }
 }
@@ -675,6 +697,8 @@ pub struct ListCustomerInvoicesRequest {
     pub pagination: PaginationParams,
     /// Invoice filters.
     pub filters: InvoiceFilters,
+    /// Search by id, number, customer name, external_id or email.
+    pub search_term: Option<String>,
 }
 
 impl ListCustomerInvoicesRequest {
@@ -690,6 +714,7 @@ impl ListCustomerInvoicesRequest {
             external_customer_id,
             pagination: PaginationParams::default(),
             filters: InvoiceFilters::default(),
+            search_term: None,
         }
     }
 
@@ -705,10 +730,23 @@ impl ListCustomerInvoicesRequest {
         self
     }
 
+    /// Sets the search term for the request.
+    ///
+    /// Search by id, number, customer name, external_id or email.
+    pub fn with_search_term(mut self, term: String) -> Self {
+        self.search_term = Some(term);
+        self
+    }
+
     /// Converts the request parameters into HTTP query parameters.
     pub fn to_query_params(&self) -> Vec<(&str, String)> {
         let mut params = self.pagination.to_query_params();
         params.extend(self.filters.to_query_params());
+
+        if let Some(ref term) = self.search_term {
+            params.push(("search_term", term.clone()));
+        }
+
         params
     }
 }


### PR DESCRIPTION
**Description**

Add `search_term` parameter to `InvoiceFilters` to enable searching invoices by id, number, customer name, external_id, or email. This aligns with the Lago API's search_term query parameter.