### PR TITLE
Feat: add /fees endpoint support to lago-types and lago-client

### DIFF
--- a/lago-types/src/filters.rs
+++ b/lago-types/src/filters.rs
@@ -7,6 +7,7 @@ pub mod coupon;
 pub mod credit_note;
 pub mod customer;
 pub mod date_range;
+pub mod fee;
 pub mod invoice;
 pub mod plan;
 pub mod subscription;

--- a/lago-types/src/filters/fee.rs
+++ b/lago-types/src/filters/fee.rs
@@ -1,0 +1,168 @@
+use serde::{Deserialize, Serialize};
+
+use crate::filters::{common::ListFilters, customer::CustomerFilter, date_range::DateRangeFilter};
+
+use crate::models::{FeePaymentStatus, FeeType};
+
+/// Filter parameters for fee list operations.
+///
+/// This struct represents the available filters that can be applied when
+/// querying fee lists from the `/fees` API endpoint, combining customer,
+/// date range, fee type, payment status, billable metric, subscription, and
+/// currency filters.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FeeFilters {
+    pub customer_filter: CustomerFilter,
+    pub date_filter: DateRangeFilter,
+    pub fee_type: Option<FeeType>,
+    pub payment_status: Option<FeePaymentStatus>,
+    pub billable_metric_code: Option<String>,
+    pub external_subscription_id: Option<String>,
+    pub currency: Option<String>,
+}
+
+impl FeeFilters {
+    /// Creates a new empty fee filter.
+    ///
+    /// # Returns
+    /// A new `FeeFilters` instance with no filters set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the external customer ID filter.
+    ///
+    /// # Arguments
+    /// * `customer_id` - The external customer ID to filter by
+    ///
+    /// # Returns
+    /// The modified filter instance for method chaining.
+    pub fn with_customer_id(mut self, customer_id: String) -> Self {
+        self.customer_filter = self.customer_filter.with_customer_id(customer_id);
+        self
+    }
+
+    /// Sets both the start and end dates for the created-at filter range.
+    ///
+    /// # Arguments
+    /// * `from` - The start date string (YYYY-MM-DD or ISO 8601)
+    /// * `to` - The end date string (YYYY-MM-DD or ISO 8601)
+    ///
+    /// # Returns
+    /// The modified filter instance for method chaining.
+    pub fn with_date_range(mut self, from: String, to: String) -> Self {
+        self.date_filter = self.date_filter.with_date_range(from, to);
+        self
+    }
+
+    /// Sets the start date for the created-at filter.
+    pub fn with_created_at_from(mut self, from: String) -> Self {
+        self.date_filter = self.date_filter.with_from_date(from);
+        self
+    }
+
+    /// Sets the end date for the created-at filter.
+    pub fn with_created_at_to(mut self, to: String) -> Self {
+        self.date_filter = self.date_filter.with_to_date(to);
+        self
+    }
+
+    /// Sets the fee type filter.
+    pub fn with_fee_type(mut self, fee_type: FeeType) -> Self {
+        self.fee_type = Some(fee_type);
+        self
+    }
+
+    /// Sets the payment status filter.
+    pub fn with_payment_status(mut self, payment_status: FeePaymentStatus) -> Self {
+        self.payment_status = Some(payment_status);
+        self
+    }
+
+    /// Sets the billable metric code filter.
+    pub fn with_billable_metric_code(mut self, code: String) -> Self {
+        self.billable_metric_code = Some(code);
+        self
+    }
+
+    /// Sets the external subscription ID filter.
+    pub fn with_external_subscription_id(mut self, id: String) -> Self {
+        self.external_subscription_id = Some(id);
+        self
+    }
+
+    /// Sets the currency filter (ISO 4217 code, e.g., "USD").
+    pub fn with_currency(mut self, currency: String) -> Self {
+        self.currency = Some(currency);
+        self
+    }
+}
+
+/// Serializes a fee type enum to the snake_case wire format expected by the API.
+fn fee_type_param(ft: &FeeType) -> &'static str {
+    match ft {
+        FeeType::Charge => "charge",
+        FeeType::AddOn => "add_on",
+        FeeType::Subscription => "subscription",
+        FeeType::Credit => "credit",
+        FeeType::Commitment => "commitment",
+    }
+}
+
+/// Serializes a fee payment status enum to the snake_case wire format expected by the API.
+fn fee_payment_status_param(s: &FeePaymentStatus) -> &'static str {
+    match s {
+        FeePaymentStatus::Pending => "pending",
+        FeePaymentStatus::Succeeded => "succeeded",
+        FeePaymentStatus::Failed => "failed",
+        FeePaymentStatus::Refunded => "refunded",
+    }
+}
+
+impl ListFilters for FeeFilters {
+    /// Converts the fee filters into HTTP query parameters.
+    ///
+    /// Date filters are mapped to fee-specific parameter names
+    /// (`created_at_from`, `created_at_to`).
+    ///
+    /// # Returns
+    /// A vector of query parameter tuples containing all the filter criteria.
+    fn to_query_params(&self) -> Vec<(&str, String)> {
+        let mut params: Vec<(&str, String)> = Vec::new();
+
+        params.extend(self.customer_filter.to_query_params());
+
+        for (key, value) in self.date_filter.to_query_params() {
+            match key {
+                "from_date" => params.push(("created_at_from", value)),
+                "to_date" => params.push(("created_at_to", value)),
+                _ => params.push((key, value)),
+            }
+        }
+
+        if let Some(fee_type) = &self.fee_type {
+            params.push(("fee_type", fee_type_param(fee_type).to_string()));
+        }
+
+        if let Some(payment_status) = &self.payment_status {
+            params.push((
+                "payment_status",
+                fee_payment_status_param(payment_status).to_string(),
+            ));
+        }
+
+        if let Some(code) = &self.billable_metric_code {
+            params.push(("billable_metric_code", code.clone()));
+        }
+
+        if let Some(sub_id) = &self.external_subscription_id {
+            params.push(("external_subscription_id", sub_id.clone()));
+        }
+
+        if let Some(currency) = &self.currency {
+            params.push(("currency", currency.clone()));
+        }
+
+        params
+    }
+}

--- a/lago-types/src/models/invoice.rs
+++ b/lago-types/src/models/invoice.rs
@@ -139,6 +139,18 @@ pub struct FeeItem {
     pub description: Option<String>,
 }
 
+/// Type of a fee, used when filtering the `/fees` endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, EnumString, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum FeeType {
+    Charge,
+    AddOn,
+    Subscription,
+    Credit,
+    Commitment,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, EnumString)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]

--- a/lago-types/src/requests.rs
+++ b/lago-types/src/requests.rs
@@ -7,6 +7,7 @@ pub mod credit_note;
 pub mod customer;
 pub mod customer_usage;
 pub mod event;
+pub mod fee;
 pub mod invoice;
 pub mod payment;
 pub mod plan;

--- a/lago-types/src/requests/fee.rs
+++ b/lago-types/src/requests/fee.rs
@@ -1,0 +1,72 @@
+use crate::filters::{common::ListFilters, fee::FeeFilters};
+use crate::models::PaginationParams;
+
+/// Request parameters for listing fees from the `/fees` endpoint.
+///
+/// This struct combines pagination parameters and fee-specific filters
+/// to build a comprehensive request for retrieving fee lists.
+#[derive(Debug, Clone)]
+pub struct ListFeesRequest {
+    pub pagination: PaginationParams,
+    pub filters: FeeFilters,
+}
+
+impl ListFeesRequest {
+    /// Creates a new empty list fees request.
+    ///
+    /// # Returns
+    /// A new `ListFeesRequest` instance with default pagination and no filters.
+    pub fn new() -> Self {
+        Self {
+            pagination: PaginationParams::default(),
+            filters: FeeFilters::default(),
+        }
+    }
+
+    /// Sets the pagination parameters for the request.
+    pub fn with_pagination(mut self, pagination: PaginationParams) -> Self {
+        self.pagination = pagination;
+        self
+    }
+
+    /// Sets the fee filters for the request.
+    pub fn with_filters(mut self, filters: FeeFilters) -> Self {
+        self.filters = filters;
+        self
+    }
+
+    /// Converts the request parameters into HTTP query parameters.
+    ///
+    /// # Returns
+    /// A vector of query parameter tuples containing both pagination and filter criteria.
+    pub fn to_query_params(&self) -> Vec<(&str, String)> {
+        let mut params = self.pagination.to_query_params();
+        params.extend(self.filters.to_query_params());
+        params
+    }
+}
+
+impl Default for ListFeesRequest {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Request parameters for retrieving a specific fee by its Lago ID.
+#[derive(Debug, Clone)]
+pub struct GetFeeRequest {
+    pub fee_id: String,
+}
+
+impl GetFeeRequest {
+    /// Creates a new get fee request.
+    ///
+    /// # Arguments
+    /// * `fee_id` - The Lago ID (UUID) of the fee to retrieve
+    ///
+    /// # Returns
+    /// A new `GetFeeRequest` instance with the specified fee ID.
+    pub fn new(fee_id: String) -> Self {
+        Self { fee_id }
+    }
+}

--- a/lago-types/src/responses.rs
+++ b/lago-types/src/responses.rs
@@ -7,6 +7,7 @@ pub mod credit_note;
 pub mod customer;
 pub mod customer_usage;
 pub mod event;
+pub mod fee;
 pub mod invoice;
 pub mod payment;
 pub mod plan;

--- a/lago-types/src/responses/fee.rs
+++ b/lago-types/src/responses/fee.rs
@@ -1,0 +1,21 @@
+use crate::models::{Fee, PaginationMeta};
+use serde::{Deserialize, Serialize};
+
+/// Response containing a list of fees with pagination metadata.
+///
+/// This struct represents the API response for fee listing requests,
+/// including both the fee data and pagination information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListFeesResponse {
+    pub fees: Vec<Fee>,
+    pub meta: PaginationMeta,
+}
+
+/// Response containing a single fee.
+///
+/// This struct represents the API response for retrieving a specific
+/// fee by its Lago ID.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetFeeResponse {
+    pub fee: Fee,
+}


### PR DESCRIPTION
## Summary

Adds the type definitions needed to consume Lago's `/fees` endpoint from the Rust SDK: `FeeType` enum, `FeeFilters`, request and response shapes. The matching client-side methods (`LagoClient::list_fees`, `LagoClient::get_fee`) will follow in a separate PR after this lands and `lago-types` is published.

## What this PR adds

- `models::FeeType` — new enum: `Charge`, `AddOn`, `Subscription`, `Credit`, `Commitment`. Added in `models/invoice.rs` next to the existing `Fee`, `FeePaymentStatus`, and `FeeItem` types, which are reused as-is.
- `filters::fee::FeeFilters` — composes `CustomerFilter`, `DateRangeFilter`, plus scalars: `fee_type`, `payment_status`, `billable_metric_code`, `external_subscription_id`, `currency`. Date range maps to `created_at_from` / `created_at_to`.
- `requests::fee::ListFeesRequest`, `requests::fee::GetFeeRequest`
- `responses::fee::ListFeesResponse`, `responses::fee::GetFeeResponse`

## What this PR does NOT add (intentional)

- `LagoClient::list_fees` / `LagoClient::get_fee` — split into a follow-up PR after this lands. CI here would have required `lago-client` to build against an unpublished `lago-types`, which is incompatible with the repo's `cargo publish --dry-run` policy. The follow-up will bump `lago-client`'s `lago-types` dep to whatever version this lands as.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [x] `cargo test --all-features` — passes (no new tests; existing 8 doctests still pass)
- [x] `cargo build --release --all-features` — clean
- [x] `cargo publish --dry-run` for `lago-types` — clean
- [x] `cargo publish --dry-run` for `lago-client` — clean (no functional change in lago-client)

## Followups

- **Publish `lago-types 0.1.22`** — needed before the lago-client work can land.
- **lago-client PR** — adds `list_fees` and `get_fee` methods, plus an example. Will be opened against `main` once this is merged and the new `lago-types` version is on crates.io.
- **lago-agent-toolkit PR** — adds the MCP tools that consume the new `LagoClient` methods. Opens after the lago-client PR lands.