### PR TITLE
chore: bump lago-types to 0.1.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ name = "lago-client"
 version = "0.1.24"
 dependencies = [
  "anyhow",
- "lago-types 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lago-types 0.1.22",
  "mockito",
  "reqwest",
  "serde",
@@ -645,6 +645,8 @@ dependencies = [
 [[package]]
 name = "lago-types"
 version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9eeefd92df4e0359cbb6bf17b9eef308b8de645841e0ccd5ff26de12d2c473"
 dependencies = [
  "chrono",
  "reqwest",
@@ -658,9 +660,7 @@ dependencies = [
 
 [[package]]
 name = "lago-types"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9eeefd92df4e0359cbb6bf17b9eef308b8de645841e0ccd5ff26de12d2c473"
+version = "0.1.23"
 dependencies = [
  "chrono",
  "reqwest",

--- a/lago-types/Cargo.toml
+++ b/lago-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lago-types"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2024"
 authors = ["Lago Team <tech@getlago.com>"]
 description = "Types definitions for Lago API"


### PR DESCRIPTION
## Summary

Bumps `lago-types` from `0.1.22` to `0.1.23` so a publish to crates.io can include the `/fees` endpoint type support that landed in #44.

## Context

PR #44 (merged May 19) added `FeeType`, `FeeFilters`, and the request/response shapes for `/fees`. But `lago-types 0.1.22` on crates.io was published on May 11 — before #44 merged — so the published package doesn't contain the fee modules.

Downstream work is blocked on a release that includes them:

- A follow-up `lago-client` PR that adds `list_fees` and `get_fee` methods + example
- A downstream MCP tools PR in [`getlago/lago-agent-toolkit`](https://github.com/getlago/lago-agent-toolkit) that exposes those methods as MCP tools

This PR is intentionally minimal — just the version bump — so it can be merged and published quickly without coupling to the follow-up code changes.

## What this PR does

- `lago-types/Cargo.toml`: `0.1.22` → `0.1.23`
- `Cargo.lock`: regenerated accordingly

No code changes.

## Action requested

After merging, please `cargo publish` from `lago-types/` to push `0.1.23` to crates.io. The dry-run is clean locally:

\`\`\`
Packaging lago-types v0.1.23
Packaged 75 files, 324.7KiB (50.3KiB compressed)
Verifying lago-types v0.1.23
\`\`\`

(75 files vs the 69 in the older 0.1.22 — the diff is the fee modules from #44.)

I'll open the lago-client follow-up PR as soon as 0.1.23 is on the registry.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-features -- -D warnings\`
- [x] \`cargo test --all-features\`
- [x] \`cargo build --release --all-features\`
- [x] \`cargo publish --dry-run\` for both crates