### PR TITLE
feat(client): add list_fees and get_fee methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,10 +627,10 @@ dependencies = [
 
 [[package]]
 name = "lago-client"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "anyhow",
- "lago-types 0.1.22",
+ "lago-types 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito",
  "reqwest",
  "serde",
@@ -644,9 +644,7 @@ dependencies = [
 
 [[package]]
 name = "lago-types"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9eeefd92df4e0359cbb6bf17b9eef308b8de645841e0ccd5ff26de12d2c473"
+version = "0.1.23"
 dependencies = [
  "chrono",
  "reqwest",
@@ -661,6 +659,8 @@ dependencies = [
 [[package]]
 name = "lago-types"
 version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d484cc75281cf030334eb5b05ec21cb16e85a29f5f2046f494ae8c9e6c9482"
 dependencies = [
  "chrono",
  "reqwest",

--- a/lago-client/Cargo.toml
+++ b/lago-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lago-client"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2024"
 authors = ["Lago Team <tech@getlago.com>"]
 description = "Lago API client"
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/getlago/lago-rust-client"
 
 [dependencies]
-lago-types = "0.1.22"
+lago-types = "0.1.23"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/lago-client/Cargo.toml
+++ b/lago-client/Cargo.toml
@@ -63,6 +63,10 @@ name = "event"
 path = "examples/event.rs"
 
 [[example]]
+name = "fee"
+path = "examples/fee.rs"
+
+[[example]]
 name = "credit_note"
 path = "examples/credit_note.rs"
 

--- a/lago-client/examples/fee.rs
+++ b/lago-client/examples/fee.rs
@@ -1,0 +1,58 @@
+use lago_client::LagoClient;
+use lago_types::{
+    filters::fee::FeeFilters,
+    models::FeeType,
+    requests::fee::{GetFeeRequest, ListFeesRequest},
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = LagoClient::from_env()?;
+
+    // Example 1: list a few recent fees with default filters
+    let list_request = ListFeesRequest::new();
+    let fees = client.list_fees(Some(list_request)).await?;
+    println!("Found {} fees", fees.fees.len());
+
+    for fee in fees.fees.iter().take(5) {
+        println!(
+            "  Fee {}: {} {} | {:?} | {:?}",
+            fee.lago_id, fee.amount_cents, fee.amount_currency, fee.payment_status, fee.item
+        );
+    }
+
+    // Example 2: list only subscription fees (typical MRR base)
+    let subscription_filters = FeeFilters::new().with_fee_type(FeeType::Subscription);
+    let subscription_request = ListFeesRequest::new().with_filters(subscription_filters);
+    let subscription_fees = client.list_fees(Some(subscription_request)).await?;
+    println!(
+        "\nFound {} subscription fees (recurring revenue)",
+        subscription_fees.fees.len()
+    );
+
+    // Example 3: list usage charges for a specific billable metric (e.g., "seats")
+    // — useful when MRR should include certain usage as recurring revenue.
+    let seats_filters = FeeFilters::new()
+        .with_fee_type(FeeType::Charge)
+        .with_billable_metric_code("seats".to_string());
+    let seats_request = ListFeesRequest::new().with_filters(seats_filters);
+    let seats_fees = client.list_fees(Some(seats_request)).await?;
+    println!(
+        "\nFound {} charge fees for billable metric 'seats'",
+        seats_fees.fees.len()
+    );
+
+    // Example 4: fetch a single fee by Lago ID (using first fee from the list, if any)
+    if let Some(first) = fees.fees.first() {
+        let get_request = GetFeeRequest::new(first.lago_id.to_string());
+        let single = client.get_fee(get_request).await?;
+        println!(
+            "\nRetrieved fee {}: {} {}",
+            single.fee.lago_id, single.fee.amount_cents, single.fee.amount_currency
+        );
+    } else {
+        println!("\nNo fees found, skipping single-fee retrieval example");
+    }
+
+    Ok(())
+}

--- a/lago-client/src/queries.rs
+++ b/lago-client/src/queries.rs
@@ -7,6 +7,7 @@ pub mod credit_note;
 pub mod customer;
 pub mod customer_usage;
 pub mod event;
+pub mod fee;
 pub mod invoice;
 pub mod payment;
 pub mod plan;

--- a/lago-client/src/queries/fee.rs
+++ b/lago-client/src/queries/fee.rs
@@ -1,0 +1,59 @@
+use lago_types::{
+    error::{LagoError, Result},
+    requests::fee::{GetFeeRequest, ListFeesRequest},
+    responses::fee::{GetFeeResponse, ListFeesResponse},
+};
+use url::Url;
+
+use crate::client::LagoClient;
+
+/// Fee-related operations for the Lago client.
+impl LagoClient {
+    /// Retrieves a list of fees with optional filtering parameters.
+    ///
+    /// Useful for revenue and MRR reporting that needs fee-level granularity —
+    /// invoices alone don't reveal which fees come from subscriptions, usage
+    /// charges (e.g., seats, storage), add-ons, credits, or commitments.
+    ///
+    /// # Arguments
+    /// * `request` - Optional filtering parameters for the fee list. When `None`,
+    ///   uses default pagination and no filters.
+    ///
+    /// # Returns
+    /// A `Result` containing the list of fees and pagination metadata, or an error.
+    pub async fn list_fees(
+        &self,
+        request: Option<ListFeesRequest>,
+    ) -> Result<ListFeesResponse> {
+        let request = request.unwrap_or_default();
+        let region = self.config.region()?;
+        let mut url = Url::parse(&format!("{}/fees", region.endpoint()))
+            .map_err(|e| LagoError::Configuration(format!("Invalid URL: {e}")))?;
+
+        let query_params = request.to_query_params();
+
+        if !query_params.is_empty() {
+            let query_string = query_params
+                .iter()
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect::<Vec<_>>()
+                .join("&");
+            url.set_query(Some(&query_string));
+        }
+
+        self.make_request("GET", url.as_str(), None::<&()>).await
+    }
+
+    /// Retrieves a specific fee by its Lago ID (UUID).
+    ///
+    /// # Arguments
+    /// * `request` - The request containing the fee's Lago ID
+    ///
+    /// # Returns
+    /// A `Result` containing the fee data or an error.
+    pub async fn get_fee(&self, request: GetFeeRequest) -> Result<GetFeeResponse> {
+        let region = self.config.region()?;
+        let url = format!("{}/fees/{}", region.endpoint(), request.fee_id);
+        self.make_request("GET", &url, None::<&()>).await
+    }
+}

--- a/lago-client/src/queries/fee.rs
+++ b/lago-client/src/queries/fee.rs
@@ -50,7 +50,9 @@ impl LagoClient {
     /// A `Result` containing the fee data or an error.
     pub async fn get_fee(&self, request: GetFeeRequest) -> Result<GetFeeResponse> {
         let region = self.config.region()?;
-        let url = format!("{}/fees/{}", region.endpoint(), request.fee_id);
-        self.make_request("GET", &url, None::<&()>).await
+        let url = Url::parse(&format!("{}/fees/{}", region.endpoint(), request.fee_id))
+            .map_err(|e| LagoError::Configuration(format!("Invalid URL: {e}")))?;
+
+        self.make_request("GET", url.as_str(), None::<&()>).await
     }
 }

--- a/lago-client/src/queries/fee.rs
+++ b/lago-client/src/queries/fee.rs
@@ -21,10 +21,7 @@ impl LagoClient {
     ///
     /// # Returns
     /// A `Result` containing the list of fees and pagination metadata, or an error.
-    pub async fn list_fees(
-        &self,
-        request: Option<ListFeesRequest>,
-    ) -> Result<ListFeesResponse> {
+    pub async fn list_fees(&self, request: Option<ListFeesRequest>) -> Result<ListFeesResponse> {
         let request = request.unwrap_or_default();
         let region = self.config.region()?;
         let mut url = Url::parse(&format!("{}/fees", region.endpoint()))


### PR DESCRIPTION
## Summary

Adds two read-only client methods consuming the `/fees` endpoint types that landed in #44 + were published as `lago-types 0.1.23` (via #45):

- **`LagoClient::list_fees(Option<ListFeesRequest>)`** — list with `FeeFilters` (fee_type, billable_metric_code, customer, subscription, currency, payment_status, created_at_from/to) plus pagination
- **`LagoClient::get_fee(GetFeeRequest)`** — single fee by Lago ID (UUID)

Plus an `examples/fee.rs` showing the four common flows: default list, filter by `FeeType::Subscription` (MRR base), filter by `billable_metric_code` (selected usage charges), single-fee lookup.

## Context

Downstream consumers — including the [Lago Agent Toolkit MCP server](https://github.com/getlago/lago-agent-toolkit) need fee-level data access. Today the SDK exposes invoices but no way to drill into the fee breakdown. This PR closes that gap by adding the client methods on top of #44's types and #45's release.

## Implementation notes

- Mirrors the existing `invoice.rs` query module pattern
- `get_fee` uses `Url::parse` with `LagoError::Configuration` mapping, matching the convention from `update_billable_metric` (#38)
- Both methods are read-only

## Version bumps

- `lago-client`: `0.1.24` → `0.1.25` (this PR adds two new public methods)
- `lago-client/Cargo.toml` dep: `lago-types = "0.1.22"` → `"0.1.23"` (consumes #44's fee modules via the #45 publish)
- `Cargo.lock`: regenerated; lago-client now resolves `lago-types 0.1.23` from the registry

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo test --all-features`
- [x] `cargo build --release --all-features`
- [x] `cargo publish --dry-run` for both `lago-types` and `lago-client`
- [x] Smoke-tested locally end-to-end through the downstream MCP server against a real Lago account (4,521 fees in test data, `list_fees` and `get_fee` both return correctly through `tools/call`)

## Commits

```
1c8b071 chore: bump lago-client to 0.1.25 and lago-types dep to 0.1.23
d827d77 refactor(client): use Url::parse in get_fee
c94deb9 style: format list_fees signature per cargo fmt
4967b91 feat(client): add fee usage example
06a2f9f feat(client): add list_fees and get_fee methods on LagoClient
```

## Followups (separate PR)

- Downstream PR in `getlago/lago-agent-toolkit` adding `list_fees` / `get_fee` as MCP tools — branch is ready, blocked on this PR + a `lago-client 0.1.25` publish.