### PR TITLE
feat(subscriptions): add activation_rules, cancellation_reason and activated_at

### DIFF
--- a/lago-types/src/models/subscription.rs
+++ b/lago-types/src/models/subscription.rs
@@ -51,6 +51,12 @@ pub struct Subscription {
     pub current_billing_period_ending_at: Option<DateTime<Utc>>,
     /// The associated plan details.
     pub plan: Option<SubscriptionPlan>,
+    /// Reason a payment-gated subscription was canceled before activation.
+    pub cancellation_reason: Option<SubscriptionCancellationReason>,
+    /// When a payment-gated subscription was activated (incomplete -> active).
+    pub activated_at: Option<DateTime<Utc>>,
+    /// Activation rules gating the subscription activation.
+    pub activation_rules: Option<Vec<SubscriptionActivationRule>>,
 }
 
 /// Billing time determines when recurring billing cycles occur.
@@ -77,6 +83,9 @@ pub enum SubscriptionStatus {
     Pending,
     /// Subscription has been terminated.
     Terminated,
+    /// Subscription was created with a payment activation rule and is waiting
+    /// for the gating payment to succeed before becoming active.
+    Incomplete,
 }
 
 /// Plan details associated with a subscription.
@@ -106,4 +115,65 @@ pub struct SubscriptionPlan {
     pub pay_in_advance: bool,
     /// Whether charges are billed monthly for yearly plans.
     pub bill_charges_monthly: Option<bool>,
+}
+
+/// Reason a payment-gated subscription was canceled before activation.
+#[derive(Debug, Clone, Serialize, Deserialize, EnumString, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum SubscriptionCancellationReason {
+    /// The gating payment failed.
+    PaymentFailed,
+    /// The activation rule expired before the payment succeeded.
+    Timeout,
+}
+
+/// Type of a subscription activation rule.
+#[derive(Debug, Clone, Serialize, Deserialize, EnumString, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum SubscriptionActivationRuleType {
+    /// Gates activation on a successful first payment.
+    Payment,
+}
+
+/// Evaluation status of a subscription activation rule.
+#[derive(Debug, Clone, Serialize, Deserialize, EnumString, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum SubscriptionActivationRuleStatus {
+    /// The rule has not been evaluated yet.
+    Inactive,
+    /// The rule is applicable and waiting to be satisfied.
+    Pending,
+    /// The rule has been satisfied.
+    Satisfied,
+    /// The rule was applicable but was declined.
+    Declined,
+    /// The rule could not be satisfied (e.g. the payment failed).
+    Failed,
+    /// The rule was not satisfied before its timeout elapsed.
+    Expired,
+    /// The rule did not apply to this subscription.
+    NotApplicable,
+}
+
+/// An activation rule attached to a subscription.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubscriptionActivationRule {
+    /// Unique identifier for the activation rule in Lago.
+    pub lago_id: Uuid,
+    /// The type of the activation rule.
+    #[serde(rename = "type")]
+    pub rule_type: SubscriptionActivationRuleType,
+    /// Hours the subscription stays incomplete awaiting payment before cancellation.
+    pub timeout_hours: i64,
+    /// Current evaluation status of the rule.
+    pub status: SubscriptionActivationRuleStatus,
+    /// When the rule expires (null until evaluation starts).
+    pub expires_at: Option<DateTime<Utc>>,
+    /// When the rule was created.
+    pub created_at: DateTime<Utc>,
+    /// When the rule was last updated.
+    pub updated_at: DateTime<Utc>,
 }

--- a/lago-types/src/requests/subscription.rs
+++ b/lago-types/src/requests/subscription.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::filters::common::ListFilters;
 use crate::filters::subscription::SubscriptionFilters;
-use crate::models::{PaginationParams, SubscriptionBillingTime};
+use crate::models::{PaginationParams, SubscriptionActivationRuleType, SubscriptionBillingTime};
 
 /// Request parameters for listing subscriptions.
 #[derive(Debug, Clone)]
@@ -124,6 +124,9 @@ pub struct CreateSubscriptionInput {
     /// Plan overrides to customize the plan for this subscription.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plan_overrides: Option<SubscriptionPlanOverrides>,
+    /// Activation rules that gate the subscription activation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub activation_rules: Option<Vec<SubscriptionActivationRuleInput>>,
 }
 
 impl CreateSubscriptionInput {
@@ -138,6 +141,7 @@ impl CreateSubscriptionInput {
             subscription_at: None,
             ending_at: None,
             plan_overrides: None,
+            activation_rules: None,
         }
     }
 
@@ -176,6 +180,15 @@ impl CreateSubscriptionInput {
         self.plan_overrides = Some(plan_overrides);
         self
     }
+
+    /// Sets the activation rules.
+    pub fn with_activation_rules(
+        mut self,
+        activation_rules: Vec<SubscriptionActivationRuleInput>,
+    ) -> Self {
+        self.activation_rules = Some(activation_rules);
+        self
+    }
 }
 
 /// Request for creating a subscription.
@@ -211,6 +224,9 @@ pub struct UpdateSubscriptionInput {
     /// Plan overrides to customize the plan for this subscription.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plan_overrides: Option<SubscriptionPlanOverrides>,
+    /// Activation rules that gate the subscription activation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub activation_rules: Option<Vec<SubscriptionActivationRuleInput>>,
 }
 
 impl UpdateSubscriptionInput {
@@ -222,6 +238,7 @@ impl UpdateSubscriptionInput {
             plan_code: None,
             subscription_at: None,
             plan_overrides: None,
+            activation_rules: None,
         }
     }
 
@@ -252,6 +269,15 @@ impl UpdateSubscriptionInput {
     /// Sets plan overrides.
     pub fn with_plan_overrides(mut self, plan_overrides: SubscriptionPlanOverrides) -> Self {
         self.plan_overrides = Some(plan_overrides);
+        self
+    }
+
+    /// Sets the activation rules.
+    pub fn with_activation_rules(
+        mut self,
+        activation_rules: Vec<SubscriptionActivationRuleInput>,
+    ) -> Self {
+        self.activation_rules = Some(activation_rules);
         self
     }
 }
@@ -425,4 +451,31 @@ pub struct SubscriptionChargeOverride {
     /// Override the pricing properties.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<serde_json::Value>,
+}
+
+/// Input for an activation rule that gates a subscription's activation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubscriptionActivationRuleInput {
+    /// The type of the activation rule.
+    #[serde(rename = "type")]
+    pub rule_type: SubscriptionActivationRuleType,
+    /// Hours the subscription stays incomplete awaiting payment before cancellation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_hours: Option<i64>,
+}
+
+impl SubscriptionActivationRuleInput {
+    /// Creates a new activation rule input of the given type.
+    pub fn new(rule_type: SubscriptionActivationRuleType) -> Self {
+        Self {
+            rule_type,
+            timeout_hours: None,
+        }
+    }
+
+    /// Sets the timeout in hours.
+    pub fn with_timeout_hours(mut self, timeout_hours: i64) -> Self {
+        self.timeout_hours = Some(timeout_hours);
+        self
+    }
 }


### PR DESCRIPTION
Best effort adding the payment gated subscriptions feature without implementing Webhooks or other pending areas.
