### PR TITLE
Type event lago_id as String instead of Uuid

### DIFF
--- a/lago-types/src/models/event.rs
+++ b/lago-types/src/models/event.rs
@@ -9,8 +9,11 @@ use uuid::Uuid;
 /// line items based on billable metrics.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Event {
-    /// Unique identifier for the event in Lago
-    pub lago_id: Uuid,
+    /// Unique identifier for the event in Lago.
+    ///
+    /// This is an opaque identifier: a UUID for organizations on the Postgres
+    /// events store, but a composite string on the ClickHouse events store.
+    pub lago_id: String,
     /// External transaction reference provided when creating the event
     pub transaction_id: String,
     /// Lago ID of the associated customer (may be null)
@@ -29,4 +32,40 @@ pub struct Event {
     pub precise_total_amount_cents: Option<String>,
     /// Custom event metadata/properties
     pub properties: Option<Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event_json(lago_id: &str) -> String {
+        format!(
+            r#"{{
+                "lago_id": "{lago_id}",
+                "transaction_id": "event_1234",
+                "lago_customer_id": null,
+                "code": "bm_code",
+                "timestamp": "2025-07-03T15:35:00Z",
+                "lago_subscription_id": null,
+                "external_subscription_id": "sub_1234",
+                "created_at": "2025-07-03T15:35:22Z",
+                "precise_total_amount_cents": null,
+                "properties": null
+            }}"#
+        )
+    }
+
+    #[test]
+    fn deserializes_uuid_lago_id() {
+        let event: Event =
+            serde_json::from_str(&event_json("1a901a90-1a90-1a90-1a90-1a901a901a90")).unwrap();
+        assert_eq!(event.lago_id, "1a901a90-1a90-1a90-1a90-1a901a901a90");
+    }
+
+    #[test]
+    fn deserializes_composite_lago_id_from_clickhouse_store() {
+        let composite = "1a901a90-1a90-1a90-1a90-1a901a901a90-sub_1234-event_1234-1751549700";
+        let event: Event = serde_json::from_str(&event_json(composite)).unwrap();
+        assert_eq!(event.lago_id, composite);
+    }
 }


### PR DESCRIPTION
The API does not guarantee lago_id is a UUID for events. On organizations using the ClickHouse events store, lago_id is a composite string, so serde deserialization into Uuid fails and events cannot be read.

lago_id on Event is now a String, treated as an opaque identifier. lago_customer_id and lago_subscription_id stay as Uuid. Added deserialization tests for both the UUID and composite forms.

Breaking change for consumers of Event::lago_id; needs a major version bump on release.